### PR TITLE
Migrate to singalwire freeswitch github repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN for i in $(seq 1 8); do mkdir -p "/usr/share/man/man${i}"; done \
     && apt-get -y --quiet --no-install-recommends build-dep freeswitch \
     && cd /usr/local/src \
     && git clone https://github.com/davehorton/drachtio-freeswitch-modules.git -b v0.2.2 \
-    && git clone https://freeswitch.org/stash/scm/fs/freeswitch.git -bv1.8.5 freeswitch \
+    && git clone https://github.com/signalwire/freeswitch.git -bv1.8.5 freeswitch \
     && cd freeswitch/libs \
     && git clone https://github.com/warmcat/libwebsockets.git  -b v3.2.0 \
     && cd libwebsockets && mkdir -p build && cd build && cmake .. && make && make install \


### PR DESCRIPTION
Old git address asks for username:
New one that works:
`git clone https://github.com/signalwire/freeswitch.git -bv1.8.5 freeswitch`